### PR TITLE
Check scrollbar height for large collections

### DIFF
--- a/addon/classes/scrollable.js
+++ b/addon/classes/scrollable.js
@@ -96,8 +96,14 @@ export default class Scrollable {
     // Offset of 2px allows for a small top/bottom or left/right margin around handle.
     let handleOffset = Math.round(scrollbarRatio * scrollOffset) + 2;
 
+    let handleSize = 0;
+
     // check if content is scrollbar is longer than content
-    let handleSize = scrollbarRatio > 1 ? 0 : Math.floor(scrollbarRatio * (scrollbarSize - 2)) - 2;
+    if (scrollbarRatio < 1) {
+      let handleSizeCalculated = Math.floor(scrollbarRatio * (scrollbarSize - 2)) - 2;
+      // check if handleSize is too small
+      handleSize = handleSizeCalculated < 10 ? 10 : handleSizeCalculated;
+    }
 
     this.updateHandle(handleOffset, handleSize);
    }


### PR DESCRIPTION
Hello. 
Thanks for great add-on.
For my collection of > 1000 items calculations of scrollbar not working correctly.
scrollbarRation is less than 0.001 and scrollbar handle not even visible.

I made some changes to calculation of scrollbar handle height, so I set a minimum value of scrollbar ratio so handle has some height.