### PR TITLE
Add scrollTop action which can be triggered from outside

### DIFF
--- a/addon/components/ember-scrollable.js
+++ b/addon/components/ember-scrollable.js
@@ -236,6 +236,13 @@ export default Ember.Component.extend(InboundActionsMixin, {
     update(value) {
       scheduleOnce('afterRender', this, this.resizeScrollbar);
       return value;
+    },
+
+    /**
+     * Scroll Top action should be called when when the scroll area should be scrolled top manually
+     */
+    scrollTop() {
+      this.get('scrollbar').scrollTo(0);
     }
   }
 });

--- a/addon/templates/components/ember-scrollable.hbs
+++ b/addon/templates/components/ember-scrollable.hbs
@@ -5,6 +5,7 @@
     {{yield (hash 
       recalculate=(action 'recalculate')
       update=(action 'update')
+      scrollTop=(action 'scrollTop')
     )}}
   </div>
 </div>


### PR DESCRIPTION
Add action and hash to manually scroll the scrollable area to top.
Initiated by https://github.com/alphasights/ember-scrollable/issues/15.