### PR TITLE
scrollTo and onScoll

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ The component accepts the following options:
 
 - `horizontal`: Enables horizontal scrolling (default: `false`)
 - `autoHide`: Enables auto hiding of the scrollbars on mouse out (default: `true`)
+- `scrollTo`: Set this property to manually scroll to a certain position
+- `onScroll(scrollOffset, event)`: action triggered whenever the user scrolls, called with the current `scrollOffset` and the original scroll `event`
 - `onScrolledToBottom`: action triggered when user scrolled to the bottom
 
 ## Developing

--- a/addon/components/ember-scrollable.js
+++ b/addon/components/ember-scrollable.js
@@ -168,7 +168,7 @@ export default Ember.Component.extend(InboundActionsMixin, {
 
     this.checkScrolledToBottom();
 
-    debounce(this, this.sendScroll, event, 100);
+    this.sendScroll(event);
   },
 
   checkScrolledToBottom() {

--- a/addon/components/ember-scrollable.js
+++ b/addon/components/ember-scrollable.js
@@ -24,6 +24,7 @@ export default Ember.Component.extend(InboundActionsMixin, {
   autoHide: true,
   scrollBuffer: 50,
   scrollTo: null,
+  _scrollTo: null,
 
   selector: computed('elementId', function(){
     return `#${this.elementId}`;
@@ -50,6 +51,16 @@ export default Ember.Component.extend(InboundActionsMixin, {
     this._scrollContentElement.on('scroll', bind(this, this.scrolled));
 
     scheduleOnce('afterRender', this, this.setupScrollbar);
+  },
+
+  didReceiveAttrs() {
+    const oldOffset = this.get('_scrollTo');
+    const newOffset = this.get('scrollTo');
+
+    if (oldOffset !== newOffset) {
+      this.set('_scrollTo', newOffset);
+      this.scrollToPosition(newOffset);
+    }
   },
 
   measureScrollbar() {
@@ -187,15 +198,15 @@ export default Ember.Component.extend(InboundActionsMixin, {
     this.sendAction('onScroll', this.get('scrollbar').scrollOffset(), event);
   },
 
-  scrollToObserver: Ember.observer('scrollTo', function() {
-    const offset = Number.parseInt(this.get('scrollTo'), 10);
+  scrollToPosition(offset) {
+    offset = Number.parseInt(offset, 10);
 
     if (Number.isNaN(offset)) {
       return;
     }
 
     this.get('scrollbar').scrollTo(offset);
-  }),
+  },
 
   resizeScrollbar() {
     let scrollbar = this.get('scrollbar');

--- a/addon/components/ember-scrollable.js
+++ b/addon/components/ember-scrollable.js
@@ -195,7 +195,9 @@ export default Ember.Component.extend(InboundActionsMixin, {
   },
 
   sendScroll(event) {
-    this.sendAction('onScroll', this.get('scrollbar').scrollOffset(), event);
+    if (this.get('onScroll')) {
+      this.sendAction('onScroll', this.get('scrollbar').scrollOffset(), event);
+    }
   },
 
   scrollToPosition(offset) {

--- a/addon/components/ember-scrollable.js
+++ b/addon/components/ember-scrollable.js
@@ -23,6 +23,7 @@ export default Ember.Component.extend(InboundActionsMixin, {
   horizontal: false,
   autoHide: true,
   scrollBuffer: 50,
+  scrollTo: null,
 
   selector: computed('elementId', function(){
     return `#${this.elementId}`;
@@ -161,11 +162,13 @@ export default Ember.Component.extend(InboundActionsMixin, {
     this.get('scrollbar').jumpScroll(e);
   },
 
-  scrolled() {
+  scrolled(event) {
     this.get('scrollbar').update();
     this.showScrollbar();
 
     this.checkScrolledToBottom();
+
+    debounce(this, this.sendScroll, event, 100);
   },
 
   checkScrolledToBottom() {
@@ -179,6 +182,20 @@ export default Ember.Component.extend(InboundActionsMixin, {
   sendScrolledToBottom() {
     this.sendAction('onScrolledToBottom');
   },
+
+  sendScroll(event) {
+    this.sendAction('onScroll', this.get('scrollbar').scrollOffset(), event);
+  },
+
+  scrollToObserver: Ember.observer('scrollTo', function() {
+    const offset = Number.parseInt(this.get('scrollTo'), 10);
+
+    if (Number.isNaN(offset)) {
+      return;
+    }
+
+    this.get('scrollbar').scrollTo(offset);
+  }),
 
   resizeScrollbar() {
     let scrollbar = this.get('scrollbar');
@@ -249,7 +266,7 @@ export default Ember.Component.extend(InboundActionsMixin, {
      * Scroll Top action should be called when when the scroll area should be scrolled top manually
      */
     scrollTop() {
-      this.get('scrollbar').scrollTo(0);
+      this.set('scrollTo', 0);
     }
   }
 });

--- a/tests/acceptance/index-test.js
+++ b/tests/acceptance/index-test.js
@@ -39,3 +39,21 @@ test('resizable scrollbar', function(assert) {
   });
 
 });
+
+test('scrollTo and onScroll', function(assert) {
+  visit('/');
+
+  andThen(function() {
+    assert.ok($('.event-and-setter-demo .ember-scrollable').length, 'scrolling demo rendered');
+    assert.ok($('.event-and-setter-demo .ember-scrollable .drag-handle').length, 'scrolling handle rendered');
+  });
+
+  const offset = 123;
+
+  fillIn('#targetScrollOffset input', offset);
+
+  andThen(function(){
+    assert.ok(~$('#currentScrollOffset').text().indexOf(String(offset)), 'scrollOffset matches');
+  });
+
+});

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -145,3 +145,53 @@
     {{code-snippet name="vertical.hbs"}}
   </div>
 </section>
+
+<section class="event-and-setter-demo">
+  <h1>Scroll event and setting the offset</h1>
+
+  <div class="output">
+    {{!-- BEGIN-SNIPPET event-and-setter --}}
+    <label id="targetScrollOffset">
+      targetScrollOffset: {{input value=targetScrollOffset type="number" min=0 step=10 max=400}}
+    </label>
+    <br>
+    <label id="currentScrollOffset">
+      currentScrollOffset: {{currentScrollOffset}} px
+    </label>
+
+    <hr>
+
+    <div style="height: 400px;">
+      {{#ember-scrollable
+        scrollTo=targetScrollOffset
+        onScroll=(action (mut currentScrollOffset))
+      }}
+        <p>Some content</p>
+        <p>Some more content</p>
+        <p>Some content</p>
+        <p>Some more content</p>
+        <p>Some content</p>
+        <p>Some more content</p>
+        <p>Some content</p>
+        <p>Some more content</p>
+        <p>Some content</p>
+        <p>Some more content</p>
+        <p>Some content</p>
+        <p>Some more content</p>
+        <p>Some content</p>
+        <p>Some more content</p>
+        <p>Some content</p>
+        <p>Some more content</p>
+        <p>Some content</p>
+        <p>Some more content</p>
+        <p>Some content</p>
+        <p>Some more content</p>
+      {{/ember-scrollable}}
+    </div>
+    {{!-- END-SNIPPET --}}
+  </div>
+
+  <div class="code">
+    {{code-snippet name="event-and-setter.hbs"}}
+  </div>
+</section>


### PR DESCRIPTION
Closes #24 and #15.

This PR adds the property `scrollTo` and the action `onScroll`.

Example usage:

```hbs
targetScrollOffset:  {{input value=targetScrollOffset type="number" min=0 step=10 max=400}}
currentScrollOffset: {{currentScrollOffset}} px

{{#ember-scrollable
  scrollTo=targetScrollOffset
  onScroll=(action (mut currentScrollOffset))
}}
  ...
{{/ember-scrollable}}
```

##### `scrollTo`
...expects a Number or String that can be parsed as a Number. It then sets the `scrollTop` (or `scrollLeft`) value of the `scrollContentElement` in accordance, whenever `scrollTo` is updated.

##### `onScroll(scrollOffset, event)`
...expects an action that is called with the current `scrollOffset` (either `scrollTop` or `scrollLeft`) and the original scroll `event`.
  `onScroll` is debounced by 100 ms, just as `onScrolledToBottom` is.