### PR TITLE
Fix scroll before render

### DIFF
--- a/addon/components/ember-scrollable.js
+++ b/addon/components/ember-scrollable.js
@@ -6,7 +6,8 @@ import { Horizontal, Vertical } from '../classes/scrollable';
 const {
   run: { scheduleOnce, debounce, bind },
   computed,
-  $
+  $,
+  isPresent
 } = Ember;
 
 const hideDelay = Ember.testing ? 16 : 1000;
@@ -98,6 +99,7 @@ export default Ember.Component.extend(InboundActionsMixin, {
 
     this.set('scrollbar', scrollbar);
 
+    this.scrollToPosition(this.get('scrollTo'));
     this.checkScrolledToBottom();
 
     if (scrollbar.isNecessary) {
@@ -207,7 +209,10 @@ export default Ember.Component.extend(InboundActionsMixin, {
       return;
     }
 
-    this.get('scrollbar').scrollTo(offset);
+    const scrollbar = this.get('scrollbar');
+    if (isPresent(scrollbar)) {
+      scrollbar.scrollTo(offset);
+    }
   },
 
   resizeScrollbar() {


### PR DESCRIPTION
As noted in https://github.com/alphasights/ember-scrollable/pull/25#discussion_r84637226, if the component is initialized with a `scrollTo` attribute, `scrollToPosition` is triggered before the component is rendered.

This PR fixes this.