### PR TITLE
Moving listeners to events on the DOM, docs, renaming

### DIFF
--- a/addon/classes/scrollable.js
+++ b/addon/classes/scrollable.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
-const { 
-  String: { camelize } 
+const {
+  String: { camelize }
 } = Ember;
 
 const pageJumpMultp = 7/8;
@@ -24,7 +24,7 @@ export default class Scrollable {
   startDrag(e) {
     this.dragOffset = this.eventOffset(e) - this.handleOffset();
   }
-  
+
   handleOffset() {
     return this.handleElement.offset()[this.offsetAttr];
   }
@@ -144,8 +144,13 @@ export class Vertical extends Scrollable {
     return e.pageY;
   }
 
+  /**
+   * Returns the offset from the anchor point derived from this MouseEvent
+   * @param e MouseEvent
+   * @return {Number}
+   */
   jumpScrollEventOffset(e) {
-    return e.originalEvent.layerY;
+    return e.layerY;
   }
 
   updateHandle(top, height) {
@@ -175,8 +180,13 @@ export class Horizontal extends Scrollable {
     return e.pageX;
   }
 
+  /**
+   * Returns the offset from the anchor point derived from this MouseEvent
+   * @param e MouseEvent
+   * @return {Number}
+   */
   jumpScrollEventOffset(e) {
-    return e.originalEvent.layerX;
+    return e.layerX;
   }
 
   updateHandle(left, width) {

--- a/addon/components/ember-scrollable.js
+++ b/addon/components/ember-scrollable.js
@@ -308,11 +308,11 @@ export default Ember.Component.extend(InboundActionsMixin, {
      *
      * for example
      * ```
-     * {{#ember-scrollable as |scrollbar|}}
+     * {{#as-scrollable as |scrollbar|}}
      *   {{#each (compute scrollbar.update rows) as |row|}}
      *     {{row.title}}
      *   {{/each}}
-     * {{/ember-scrollable}}
+     * {{/as-scrollable}}
      * ```
      */
     update(value) {

--- a/addon/templates/components/ember-scrollable.hbs
+++ b/addon/templates/components/ember-scrollable.hbs
@@ -1,6 +1,8 @@
-{{resize-detector selector on-resize=(action 'recalculate')}}
-<div class="tse-scrollbar"><div class="drag-handle {{if showHandle 'visible'}}"></div></div>
-<div class="tse-scroll-content">
+{{resize-detector (concat '#' elementId) on-resize=(action 'recalculate')}}
+<div class="tse-scrollbar" onmousedown={{action 'jumpScroll'}}>
+    <div class="drag-handle {{if showHandle 'visible'}}" onmousedown={{action 'startDrag'}}></div>
+</div>
+<div class="tse-scroll-content" onscroll={{action 'scrolled'}}>
   <div class="tse-content scrollable-content">
     {{yield (hash
       recalculate=(action 'recalculate')


### PR DESCRIPTION
First jab at making things a bit more idiomatic and reactive.
- removed the instances of `.on` and `.off` from html elements, in favor of adding actions directly on those elements.

First stab at adding documentation, will add more as I comb through the code