### PR TITLE
Guards against `set` being called on a destroyed object.

### DIFF
--- a/addon/components/ember-scrollable.js
+++ b/addon/components/ember-scrollable.js
@@ -216,6 +216,10 @@ export default Ember.Component.extend(InboundActionsMixin, {
   },
 
   resizeScrollbar() {
+    if (this.get('isDestroyed')) {
+      return;
+    }
+
     let scrollbar = this.get('scrollbar');
     if (!scrollbar) {
       return;


### PR DESCRIPTION
Before this change it was possible for `resizeScrollbar` to bomb out if it was called when in the `isDestroyed` state. It is possible for the component to both be `isDestroyed` and have a `scrollbar` still.

![](https://screen-caps.s3.amazonaws.com/f1hujQKmIH.png)

This is similar to: https://github.com/alphasights/ember-scrollable/commit/f404e12468a9d18667a8c9712643ff57d4dee450