### PR TITLE
Showing that master is broken for 1.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,4 @@ The component accepts the following options:
 ### Running Tests
 
 * `ember test --server`
+

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-inject-live-reload": "^1.4.0",
     "ember-cli-jshint": "^1.0.0",
-    "ember-cli-qunit": "^2.2.5",
+    "ember-cli-qunit": "^3.1.0",
     "ember-cli-release": "1.0.0-beta.2",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-test-loader": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-inject-live-reload": "^1.4.0",
     "ember-cli-jshint": "^1.0.0",
-    "ember-cli-qunit": "^2.1.0",
+    "ember-cli-qunit": "^2.2.5",
     "ember-cli-release": "1.0.0-beta.2",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-test-loader": "^1.1.0",


### PR DESCRIPTION
Related to the zoom? @taras 


```
not ok 4 Chrome 55.0 - Acceptance | ember-scrollbar: resizable scrollbar
actual: >
     200
expected: >
      100
stack: >
          at http://localhost:7357/assets/tests.js:26:14
          at Class.andThen (http://localhost:7357/assets/vendor.js:52564:33)
          at http://localhost:7357/assets/vendor.js:53250:19
          at isolate (http://localhost:7357/assets/vendor.js:53451:13)
          at http://localhost:7357/assets/vendor.js:53435:14
          at tryCatch (http://localhost:7357/assets/vendor.js:66669:14)
    Log: |
```