### PR TITLE
Fixing #39: Allowing to draggable elments inside of ember-scrollable

### DIFF
--- a/addon/components/ember-scrollable.js
+++ b/addon/components/ember-scrollable.js
@@ -452,15 +452,16 @@ export default Ember.Component.extend(InboundActionsMixin, DomMixin, {
   },
 
   /**
-   * Sets scrollTo{X,Y} by using the ratio of offset to content size
+   * Sets scrollTo{X,Y} by using the ratio of offset to content size.
+   * Called when the handle in ember-scrollbar is dragged.
    *
-   * @method dragHandle
+   * @method updateScrollProperty
    * @param dragPerc
    * @param scrollProp
    * @param sizeAttr
    * @private
    */
-  dragHandle(dragPerc, scrollProp, sizeAttr) {
+  updateScrollProperty(scrollProp, dragPerc, sizeAttr) {
     const srcollTo = dragPerc * this.contentSize(sizeAttr);
     this.set(scrollProp, srcollTo);
   },
@@ -531,10 +532,10 @@ export default Ember.Component.extend(InboundActionsMixin, DomMixin, {
       scheduleOnce('afterRender', this, 'scrolled', ...arguments);
     },
     horizontalDrag(dragPerc) {
-      scheduleOnce('afterRender', this, 'dragHandle', dragPerc, 'scrollToX', 'width');
+      scheduleOnce('afterRender', this, 'updateScrollProperty', 'scrollToX', dragPerc, 'width');
     },
     verticalDrag(dragPerc) {
-      scheduleOnce('afterRender', this, 'dragHandle', dragPerc, 'scrollToY', 'height');
+      scheduleOnce('afterRender', this, 'updateScrollProperty', 'scrollToY', dragPerc, 'height');
     },
     horizontalJumpTo(jumpPositive) {
       this.jumpScroll(jumpPositive, 'scrollToX', 'width');

--- a/addon/components/ember-scrollable.js
+++ b/addon/components/ember-scrollable.js
@@ -96,28 +96,6 @@ export default Ember.Component.extend(InboundActionsMixin, DomMixin, {
   scrollToY: 0,
 
   /**
-   * Action called when scrolling.
-   *
-   * First argument is the scrollOffset
-   * Second is the scroll event
-   *
-   * @property onScroll
-   * @public
-   * @type Function
-   */
-  onScroll(){},
-
-
-  /**
-   * Action called when scroll handle reaches the end of the scrollbar "track".
-   *
-   * @property onScrolledToBottom
-   * @public
-   * @type Function
-   */
-  onScrolledToBottom(){},
-
-  /**
    * Local reference the horizontal scrollbar.
    *
    * @property horizontalScrollbar
@@ -410,7 +388,7 @@ export default Ember.Component.extend(InboundActionsMixin, DomMixin, {
 
     this.checkScrolledToBottom(this.get(`${scrollDirection}Scrollbar`), scrollOffset);
 
-     this.get('onScroll')(scrollOffset, event);
+    this.sendScroll(event, scrollOffset);
   },
 
 
@@ -423,7 +401,13 @@ export default Ember.Component.extend(InboundActionsMixin, DomMixin, {
   },
 
   sendScrolledToBottom() {
-    this.get('onScrolledToBottom')();
+    this.sendAction('onScrolledToBottom');
+  },
+
+  sendScroll(event, scrollOffset) {
+    if (this.get('onScroll')) {
+      this.sendAction('onScroll', scrollOffset, event);
+    }
   },
 
   resizeScrollbar() {

--- a/addon/components/ember-scrollable.js
+++ b/addon/components/ember-scrollable.js
@@ -455,13 +455,13 @@ export default Ember.Component.extend(InboundActionsMixin, DomMixin, {
    * Sets scrollTo{X,Y} by using the ratio of offset to content size.
    * Called when the handle in ember-scrollbar is dragged.
    *
-   * @method updateScrollProperty
-   * @param dragPerc
-   * @param scrollProp
-   * @param sizeAttr
+   * @method updateScrollToProperty
+   * @param scrollProp {String} String indicating the scrollTo attribute to be updated ('scrollToX'|'scrollToY')
+   * @param dragPerc {Number} A Number from 0 - 1 indicating the position of the handle as percentage of the scrollbar
+   * @param sizeAttr {String} String indicating the attribute used to get to the size of the content ('height'|'width')
    * @private
    */
-  updateScrollProperty(scrollProp, dragPerc, sizeAttr) {
+  updateScrollToProperty(scrollProp, dragPerc, sizeAttr) {
     const srcollTo = dragPerc * this.contentSize(sizeAttr);
     this.set(scrollProp, srcollTo);
   },
@@ -532,10 +532,10 @@ export default Ember.Component.extend(InboundActionsMixin, DomMixin, {
       scheduleOnce('afterRender', this, 'scrolled', ...arguments);
     },
     horizontalDrag(dragPerc) {
-      scheduleOnce('afterRender', this, 'updateScrollProperty', 'scrollToX', dragPerc, 'width');
+      scheduleOnce('afterRender', this, 'updateScrollToProperty', 'scrollToX', dragPerc, 'width');
     },
     verticalDrag(dragPerc) {
-      scheduleOnce('afterRender', this, 'updateScrollProperty', 'scrollToY', dragPerc, 'height');
+      scheduleOnce('afterRender', this, 'updateScrollToProperty', 'scrollToY', dragPerc, 'height');
     },
     horizontalJumpTo(jumpPositive) {
       this.jumpScroll(jumpPositive, 'scrollToX', 'width');

--- a/addon/components/ember-scrollable.js
+++ b/addon/components/ember-scrollable.js
@@ -96,6 +96,28 @@ export default Ember.Component.extend(InboundActionsMixin, DomMixin, {
   scrollToY: 0,
 
   /**
+   * Action called when scrolling.
+   *
+   * First argument is the scrollOffset
+   * Second is the scroll event
+   *
+   * @property onScroll
+   * @public
+   * @type Function
+   */
+  onScroll(){},
+
+
+  /**
+   * Action called when scroll handle reaches the end of the scrollbar "track".
+   *
+   * @property onScrolledToBottom
+   * @public
+   * @type Function
+   */
+  onScrolledToBottom(){},
+
+  /**
    * Local reference the horizontal scrollbar.
    *
    * @property horizontalScrollbar
@@ -392,7 +414,7 @@ export default Ember.Component.extend(InboundActionsMixin, DomMixin, {
 
     this.checkScrolledToBottom(this.get(`${scrollDirection}Scrollbar`), scrollOffset);
 
-    this.sendScroll(event, scrollOffset);
+     this.get('onScroll')(scrollOffset, event);
   },
 
 
@@ -405,13 +427,7 @@ export default Ember.Component.extend(InboundActionsMixin, DomMixin, {
   },
 
   sendScrolledToBottom() {
-    this.sendAction('onScrolledToBottom');
-  },
-
-  sendScroll(event, scrollOffset) {
-    if (this.get('onScroll')) {
-      this.sendAction('onScroll', scrollOffset, event);
-    }
+    this.get('onScrolledToBottom')();
   },
 
   resizeScrollbar() {
@@ -442,13 +458,13 @@ export default Ember.Component.extend(InboundActionsMixin, DomMixin, {
   /**
    * Sets scrollTo{X,Y} by using the ratio of offset to content size
    *
-   * @method drag
+   * @method dragHandle
    * @param dragPerc
    * @param scrollProp
    * @param sizeAttr
    * @private
    */
-  drag(dragPerc, scrollProp, sizeAttr) {
+  dragHandle(dragPerc, scrollProp, sizeAttr) {
     const srcollTo = dragPerc * this.contentSize(sizeAttr);
     this.set(scrollProp, srcollTo);
   },
@@ -519,10 +535,10 @@ export default Ember.Component.extend(InboundActionsMixin, DomMixin, {
       this.scrolled(...arguments);
     },
     horizontalDrag(dragPerc) {
-      this.drag(dragPerc, 'scrollToX', 'width');
+      this.dragHandle(dragPerc, 'scrollToX', 'width');
     },
     verticalDrag(dragPerc) {
-      this.drag(dragPerc, 'scrollToY', 'height');
+      this.dragHandle(dragPerc, 'scrollToY', 'height');
     },
     horizontalJumpTo(jumpPositive) {
       this.jumpScroll(jumpPositive, 'scrollToX', 'width');

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "ember-code-snippet": "1.3.0",
     "ember-data": "^2.8.0",
     "ember-disable-prototype-extensions": "^1.1.0",
+    "ember-drag-drop": "0.4.2",
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -7,7 +7,7 @@ const Router = Ember.Router.extend({
 });
 
 Router.map(function() {
-  this.route('extra');
+  this.route('cookbook');
 });
 
 export default Router;

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -7,6 +7,7 @@ const Router = Ember.Router.extend({
 });
 
 Router.map(function() {
+  this.route('extra');
 });
 
 export default Router;

--- a/tests/dummy/app/templates/cookbook.hbs
+++ b/tests/dummy/app/templates/cookbook.hbs
@@ -1,6 +1,9 @@
-{{#link-to 'index'}}
-  Home
-{{/link-to}}
+<section>
+  {{#link-to 'index'}}
+    Home
+  {{/link-to}}
+  This page is for demonstrating more advanced / potentially real world uses of ember-scrollable. Please feel free to make additions if you see fit.
+</section>
 <section class="vertical-demo">
   <h1>Synchronized Scrolling</h1>
 

--- a/tests/dummy/app/templates/extra.hbs
+++ b/tests/dummy/app/templates/extra.hbs
@@ -1,0 +1,72 @@
+{{#link-to 'index'}}
+  Home
+{{/link-to}}
+<section class="vertical-demo">
+  <h1>Synchronized Scrolling</h1>
+
+  <div class="output">
+    {{!-- BEGIN-SNIPPET vertical --}}
+    <div style="height: 400px;">
+      {{#ember-scrollable scrollToY=scrollToY onScroll=(action (mut scrollToY))}}
+        <p>
+          {{#draggable-object content=this}}
+            Drag Me!
+          {{/draggable-object}}
+        </p>
+        <p>Some more content</p>
+        <p>Some content</p>
+        <p>Some more content</p>
+        <p>Some content</p>
+        <p>Some more content</p>
+        <p>Some content</p>
+        <p>Some more content</p>
+        <p>Some content</p>
+        <p>Some more content</p>
+        <p>Some content</p>
+        <p>Some more content</p>
+        <p>Some content</p>
+        <p>Some more content</p>
+        <p>Some content</p>
+        <p>Some more content</p>
+        <p>Some content</p>
+        <p>Some more content</p>
+        <p>Some content</p>
+        <p>Some more content</p>
+      {{/ember-scrollable}}
+    </div>
+    {{!-- END-SNIPPET --}}
+  </div>
+
+  <div class="output">
+    {{!-- BEGIN-SNIPPET vertical --}}
+    <div style="height: 400px;">
+      {{#ember-scrollable scrollToY=scrollToY onScroll=(action (mut scrollToY))}}
+        <p>
+          {{#draggable-object content=this}}
+            Drag Me!
+          {{/draggable-object}}
+        </p>
+        <p>Some more content</p>
+        <p>Some content</p>
+        <p>Some more content</p>
+        <p>Some content</p>
+        <p>Some more content</p>
+        <p>Some content</p>
+        <p>Some more content</p>
+        <p>Some content</p>
+        <p>Some more content</p>
+        <p>Some content</p>
+        <p>Some more content</p>
+        <p>Some content</p>
+        <p>Some more content</p>
+        <p>Some content</p>
+        <p>Some more content</p>
+        <p>Some content</p>
+        <p>Some more content</p>
+        <p>Some content</p>
+        <p>Some more content</p>
+      {{/ember-scrollable}}
+    </div>
+    {{!-- END-SNIPPET --}}
+  </div>
+</section>

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -1,6 +1,8 @@
-{{#link-to 'extra'}}
-  Extra
-{{/link-to}}
+<section>
+  {{#link-to 'cookbook'}}
+    Cookbook
+  {{/link-to}}
+</section>
 <section class="vertical-demo">
   <h1>Vertical</h1>
 
@@ -148,7 +150,6 @@
     {{code-snippet name="double.hbs"}}
   </div>
 </section>
-
 
 
 <section class="resize-demo">

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -1,3 +1,6 @@
+{{#link-to 'extra'}}
+  Extra
+{{/link-to}}
 <section class="vertical-demo">
   <h1>Vertical</h1>
 


### PR DESCRIPTION
closes https://github.com/alphasights/ember-scrollable/issues/39 
cc @dknutsen

Added an `cookbook` demo page with a draggable element inside of it, also an example of how you would synchronize two scollbars, as I thought it might be helpful.
