### PR TITLE
Documenting `onScroll` and `onScrolledToBottom` actions better

### DIFF
--- a/addon/components/ember-scrollable.js
+++ b/addon/components/ember-scrollable.js
@@ -96,6 +96,28 @@ export default Ember.Component.extend(InboundActionsMixin, DomMixin, {
   scrollToY: 0,
 
   /**
+   * Action called when scrolling.
+   *
+   * First argument is the scrollOffset
+   * Second is the scroll event
+   *
+   * @property onScroll
+   * @public
+   * @type Function
+   */
+  onScroll(){},
+
+
+  /**
+   * Action called when scroll handle reaches the end of the scrollbar "track".
+   *
+   * @property onScrolledToBottom
+   * @public
+   * @type Function
+   */
+  onScrolledToBottom(){},
+
+  /**
    * Local reference the horizontal scrollbar.
    *
    * @property horizontalScrollbar
@@ -392,7 +414,7 @@ export default Ember.Component.extend(InboundActionsMixin, DomMixin, {
 
     this.checkScrolledToBottom(this.get(`${scrollDirection}Scrollbar`), scrollOffset);
 
-    this.sendScroll(event, scrollOffset);
+     this.get('onScroll')(scrollOffset, event);
   },
 
 
@@ -405,13 +427,7 @@ export default Ember.Component.extend(InboundActionsMixin, DomMixin, {
   },
 
   sendScrolledToBottom() {
-    this.sendAction('onScrolledToBottom');
-  },
-
-  sendScroll(event, scrollOffset) {
-    if (this.get('onScroll')) {
-      this.sendAction('onScroll', scrollOffset, event);
-    }
+    this.get('onScrolledToBottom')();
   },
 
   resizeScrollbar() {


### PR DESCRIPTION
Pulled out of https://github.com/alphasights/ember-scrollable/pull/54

Note this may be a breaking change if clients were relying on the pre closure actions / 2.0 `sendAction` syntax and the associated bubbling up.

```htmlbars
{{#ember-scrollable onScroll='scrolled'}}
<!-- becomes -->
{{#ember-scrollable onScroll=(action 'scrolled')}}
```

This is still supported in Ember, but it not recommended nor referenced in the docs since 2.0 ([1.13 docs](https://guides.emberjs.com/v1.13.0/components/sending-actions-from-components-to-your-application/#toc_sending-parameters-with-an-action) v [2.0 docs](https://guides.emberjs.com/v2.0.0/components/triggering-changes-with-actions/#toc_passing-the-action-to-the-component))