### PR TITLE
Leverage ember-native-dom-helpers for better interaction testing

### DIFF
--- a/addon/components/ember-scrollbar.js
+++ b/addon/components/ember-scrollbar.js
@@ -128,16 +128,21 @@ export default Ember.Component.extend({
   },
 
   /**
-   * sends direction and scroll offset
+   * Calls `onJumpTo` action with a boolean indicating the direction of the jump, and the jQuery MouseDown event.
+   *
+   * If towardsAnchor is true, the jump is in a direction towards from the initial anchored position of the scrollbar.
+   *  i.e. for a vertical scrollbar, towardsAnchor=true indicates moving upwards, and towardsAnchor=false is downwards
+   *       for a horizontal scrollbar, towardsAnchor=true indicates moving left, and towardsAnchor=false is right
+   *
    * @param e
    * @private
    */
   _jumpScroll(e) {
     let eventOffset = this._jumpScrollEventOffset(e);
     let handleOffset = this._handlePositionOffset();
-    const jumpPositive = (eventOffset < handleOffset);
+    const towardsAnchor = (eventOffset < handleOffset);
 
-    this.get('onJumpTo')(jumpPositive, e);
+    this.get('onJumpTo')(towardsAnchor, e);
   },
 
 

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "ember-drag-drop": "0.4.2",
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",
+    "ember-native-dom-helpers": "0.2.0",
     "ember-resolver": "^2.0.3",
     "loader.js": "^4.0.11"
   },

--- a/tests/integration/components/ember-scrollbar-test.js
+++ b/tests/integration/components/ember-scrollbar-test.js
@@ -1,8 +1,6 @@
-import Ember from 'ember';
-import {moduleForComponent, test} from 'ember-qunit';
+import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-
-const {$: jQuery} = Ember;
+import { click, find, triggerEvent } from 'ember-native-dom-helpers/test-support/helpers';
 
 moduleForComponent('ember-scrollbar', 'Integration | Component | ember scrollbar', {
   integration: true
@@ -10,6 +8,14 @@ moduleForComponent('ember-scrollbar', 'Integration | Component | ember scrollbar
 
 const handleClass = '.drag-handle';
 const barClass = '.tse-scrollbar';
+
+function leftElementOffset(selector){
+  return find(selector).getBoundingClientRect().left;
+}
+
+function topElementOffset(selector){
+  return find(selector).getBoundingClientRect().top;
+}
 
 test('Horizontal: offset and size get routed properly', function(assert) {
   assert.expect(2);
@@ -32,8 +38,6 @@ test('Horizontal: offset and size get routed properly', function(assert) {
     </div>
   </div>`);
 
-  // TODO no idea why offset and width are showing up as half of the set properties
-  // they look fine when I copy this code to the test app
   assert.equal(this.$(handleClass).position().left, this.get('offset'));
   assert.equal(Number.parseInt(this.$(handleClass).css('width')), this.get('size'));
 });
@@ -59,14 +63,12 @@ test('Vertical: offset and size get routed properly', function(assert) {
     </div>
   </div>`);
 
-  // TODO no idea why offset and width are showing up as half of the set properties
-  // they look fine when I copy this code to the test app
   assert.equal(this.$(handleClass).position().top, this.get('offset'));
   assert.equal(Number.parseInt(this.$(handleClass).css('height')), this.get('size'));
 });
 
 
-test('mousedown event on handle triggers startDrag, but not onJumpTo', function(assert) {
+test('click event on handle triggers startDrag, but not onJumpTo', function(assert) {
   assert.expect(1);
 
   this.setProperties({
@@ -96,10 +98,10 @@ test('mousedown event on handle triggers startDrag, but not onJumpTo', function(
     </div>
   </div>`);
 
-  this.$(handleClass).trigger('mousedown');
+  click(handleClass);
 });
 
-test('mousedown event on bar triggers onJumpTo and not startDrag', function(assert) {
+test('clicking on bar triggers onJumpTo and not startDrag', function(assert) {
   assert.expect(1);
 
   this.setProperties({
@@ -131,14 +133,15 @@ test('mousedown event on bar triggers onJumpTo and not startDrag', function(asse
     </div>
   </div>`);
 
-  // WHEN we mousedown on the bar and not the handle
-  this.$(barClass).trigger('mousedown');
+  // WHEN we click on the bar and not the handle
+  click(barClass);
 });
 
 
-test('Horizontal: onJumpTo has positive first argument when to the left of handle', function(assert) {
+test('Horizontal: onJumpTo has positive first argument when click to the left of handle', function(assert) {
   assert.expect(1);
 
+  const deltaX =  9; // some number less than 10, therefore `towardsAnchor` will be true
   this.setProperties({
     size: 40,
     offset: 10
@@ -163,24 +166,21 @@ test('Horizontal: onJumpTo has positive first argument when to the left of handl
   </div>`);
 
   // WHEN
-  const event = jQuery.Event("mousedown");
-  // TODO for some reason the realized offset is getting set to half of what is passed in during testing
-  // change offsetX to 5+ but < 10 and the test will fail because of this
-  event.offsetX = 2;
-  this.$(barClass).trigger(event);
-
+  const clientX = leftElementOffset(barClass) + deltaX;
+  click(barClass, { clientX });
 
 });
 
-test('Horizontal: onJumpTo has negative first argument when to the right of handle', function(assert) {
+test('Horizontal: onJumpTo has negative first argument when click to the right of handle', function(assert) {
   assert.expect(1);
 
+  const deltaX = 30; // more than offset of 10
   this.setProperties({
     size: 40,
     offset: 10
   });
   this.on('onJumpTo', function(towardsAnchor) {
-    assert.notOk(towardsAnchor, 'towardsAnchor should be false if going towards away from anchor');
+    assert.notOk(towardsAnchor, 'towardsAnchor should be false if going away from anchor');
   });
 
   this.render(hbs`
@@ -199,16 +199,16 @@ test('Horizontal: onJumpTo has negative first argument when to the right of hand
   </div>`);
 
   // WHEN
-  const event = jQuery.Event("mousedown");
-  event.offsetX = 30;
-  this.$(barClass).trigger(event);
+  const clientX = leftElementOffset(barClass) + deltaX;
+  click(barClass, { clientX });
 
 });
 
 
-test('Vertical: onJumpTo has positive first argument when to the top of handle', function(assert) {
+test('Vertical: onJumpTo has positive first argument when click to the top of handle', function(assert) {
   assert.expect(1);
 
+  const deltaY = 2; // less than offset of 10
   this.setProperties({
     size: 40,
     offset: 10
@@ -233,18 +233,15 @@ test('Vertical: onJumpTo has positive first argument when to the top of handle',
   </div>`);
 
   // WHEN
-  const event = jQuery.Event("mousedown");
-  // TODO for some reason the realized offset is getting set to half of what is passed in during testing
-  // change offsetY to 5+ but < 10 and the test will fail because of this
-  event.offsetY = 2;
-  this.$(barClass).trigger(event);
-
+  const clientY = topElementOffset(barClass) + deltaY;
+  click(barClass, { clientY });
 
 });
 
-test('Vertical: onJumpTo has negative first argument when to the bottom of handle', function(assert) {
+test('Vertical: onJumpTo has negative first argument when clicking below the vertical handle', function(assert) {
   assert.expect(1);
 
+  const deltaY = 30; // more than offset of 10
   this.setProperties({
     size: 40,
     offset: 10
@@ -269,9 +266,8 @@ test('Vertical: onJumpTo has negative first argument when to the bottom of handl
   </div>`);
 
   // WHEN
-  const event = jQuery.Event("mousedown");
-  event.offsetY = 30;
-  this.$(barClass).trigger(event);
+  const clientY = topElementOffset(barClass) + deltaY;
+  click(barClass, { clientY });
 
 });
 
@@ -303,7 +299,7 @@ test('mouseup event triggers onDragEnd', function(assert) {
     </div>
   </div>`);
 
-  this.$(handleClass).trigger('mouseup');
+  triggerEvent(handleClass, 'mouseup');
 
   assert.ok(called);
 });

--- a/tests/integration/components/ember-scrollbar-test.js
+++ b/tests/integration/components/ember-scrollbar-test.js
@@ -138,7 +138,7 @@ test('clicking on bar triggers onJumpTo and not startDrag', function(assert) {
 });
 
 
-test('Horizontal: onJumpTo has positive first argument when click to the left of handle', function(assert) {
+test('Horizontal: onJumpTo first argument is true when click to the left of handle', function(assert) {
   assert.expect(1);
 
   const deltaX =  9; // some number less than 10, therefore `towardsAnchor` will be true
@@ -171,7 +171,7 @@ test('Horizontal: onJumpTo has positive first argument when click to the left of
 
 });
 
-test('Horizontal: onJumpTo has negative first argument when click to the right of handle', function(assert) {
+test('Horizontal: onJumpTo first argument is false when click to the right of handle', function(assert) {
   assert.expect(1);
 
   const deltaX = 30; // more than offset of 10
@@ -205,7 +205,7 @@ test('Horizontal: onJumpTo has negative first argument when click to the right o
 });
 
 
-test('Vertical: onJumpTo has positive first argument when click to the top of handle', function(assert) {
+test('Vertical: onJumpTo first argument is true when click to the top of handle', function(assert) {
   assert.expect(1);
 
   const deltaY = 2; // less than offset of 10
@@ -238,7 +238,7 @@ test('Vertical: onJumpTo has positive first argument when click to the top of ha
 
 });
 
-test('Vertical: onJumpTo has negative first argument when clicking below the vertical handle', function(assert) {
+test('Vertical: onJumpTo first argument is false when clicking below the vertical handle', function(assert) {
   assert.expect(1);
 
   const deltaY = 30; // more than offset of 10


### PR DESCRIPTION
Also improved the weird naming surrounding the first argument to `jumpTo` and added docs.

related:
@cibernox -- I couldn't get the equivalent of `this.$(elem).scrollTop()` or `.scrollLeft()` to work.
It seems like `scrollTop()` simply modifies the `scrollTop` property on the elment, which generates an async event that doesn't contain much info about the scroll, besides that it did (and the target element, that has the mutated property already). I haven't been able to get my tests to wait for the scroll event resolve and callback, etc.

because of this we have some nastiness in the form of arbitrary delay times..  https://github.com/alphasights/ember-scrollable/blob/master/tests/integration/components/scroll-content-element-test.js#L122

<details>
<summary> Dev console images of scroll event</summary>

![image](https://cloud.githubusercontent.com/assets/11779993/23295271/a8dae940-fa3d-11e6-89b2-8ca6db81d4c2.png)

![image](https://cloud.githubusercontent.com/assets/11779993/23295238/76feb37a-fa3d-11e6-9521-31361739eab0.png)

</details>