### PR TITLE
Fix: Scrollbar visible when content changes to no longer have overflow

### DIFF
--- a/addon/components/ember-scrollable.js
+++ b/addon/components/ember-scrollable.js
@@ -122,7 +122,7 @@ export default Ember.Component.extend(InboundActionsMixin, DomMixin, {
   didInsertElement() {
     this._super(...arguments);
     this.setupElements();
-    scheduleOnce('afterRender', this, this.setupScrollbar);
+    scheduleOnce('afterRender', this, this.createScrollbarAndShowIfNecessary);
     this.addEventListener(document.body, 'mouseup', (e) => this.endDrag(e));
     this.addEventListener(document.body, 'mousemove', (e) => {
       throttle(this, this.updateMouseOffset, e, THROTTLE_TIME_LESS_THAN_60_FPS_IN_MS);
@@ -250,7 +250,12 @@ export default Ember.Component.extend(InboundActionsMixin, DomMixin, {
 
   },
 
-  setupScrollbar() {
+  /**
+   * Used to create/reset scrollbar(s) if they are necessary
+   *
+   * @method createScrollbarAndShowIfNecessary
+   */
+  createScrollbarAndShowIfNecessary() {
     this.createScrollbar().map((scrollbar) => {
       this.checkScrolledToBottom(scrollbar);
       if (scrollbar.isNecessary) {
@@ -290,6 +295,12 @@ export default Ember.Component.extend(InboundActionsMixin, DomMixin, {
     }
   },
 
+  /**
+   * Creates the corresponding scrollbar(s) from the configured `vertical` and `horizontal` properties
+   *
+   * @method createScrollbar
+   * @return {Array} Scrollbar(s) that were created
+   */
   createScrollbar() {
     if (this.get('isDestroyed')) {
       return;
@@ -411,8 +422,7 @@ export default Ember.Component.extend(InboundActionsMixin, DomMixin, {
   },
 
   resizeScrollbar() {
-    this.createScrollbar();
-    this.showScrollbar();
+    this.createScrollbarAndShowIfNecessary();
   },
 
   showScrollbar() {

--- a/addon/components/ember-scrollbar.js
+++ b/addon/components/ember-scrollbar.js
@@ -128,16 +128,21 @@ export default Ember.Component.extend({
   },
 
   /**
-   * sends direction and scroll offset
+   * Calls `onJumpTo` action with a boolean indicating the direction of the jump, and the jQuery MouseDown event.
+   *
+   * If towardsAnchor is true, the jump is in a direction towards from the initial anchored position of the scrollbar.
+   *  i.e. for a vertical scrollbar, towardsAnchor=true indicates moving upwards, and towardsAnchor=false is downwards
+   *       for a horizontal scrollbar, towardsAnchor=true indicates moving left, and towardsAnchor=false is right
+   *
    * @param e
    * @private
    */
   _jumpScroll(e) {
     let eventOffset = this._jumpScrollEventOffset(e);
     let handleOffset = this._handlePositionOffset();
-    const jumpPositive = (eventOffset < handleOffset);
+    const towardsAnchor = (eventOffset < handleOffset);
 
-    this.get('onJumpTo')(jumpPositive, e);
+    this.get('onJumpTo')(towardsAnchor, e);
   },
 
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "ember-drag-drop": "0.4.2",
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",
-    "ember-native-dom-helpers": "0.2.0",
+    "ember-native-dom-helpers": "0.3.2",
     "ember-resolver": "^2.0.3",
     "loader.js": "^4.0.11"
   },

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "ember-drag-drop": "0.4.2",
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",
+    "ember-native-dom-helpers": "0.2.0",
     "ember-resolver": "^2.0.3",
     "loader.js": "^4.0.11"
   },

--- a/tests/acceptance/index-test.js
+++ b/tests/acceptance/index-test.js
@@ -68,3 +68,33 @@ test('scrollTo and onScroll', function(assert) {
 
 });
 
+
+test('When element resized from no-overflow => overflow => no-overflow, no scrollbar is visible on mouseover', function(assert) {
+  let scrollArea;
+  let toggleButtonSelector = '.no-scrollbar-demo button';
+  visit('/');
+
+  andThen(function() {
+    assert.ok(find('.no-scrollbar-demo .ember-scrollable'), 'resize demo rendered');
+    assert.ok(find('.no-scrollbar-demo .ember-scrollable .drag-handle:not(.visible)'), 'resize handle rendered, but not visible');
+    scrollArea = find('.no-scrollbar-demo .ember-scrollable .tse-content');
+    assert.equal(elementHeight(scrollArea), 18, 'there is no overflow as 18 < 200px');
+
+    click(toggleButtonSelector);
+  });
+
+  andThen(function() {
+    assert.equal(elementHeight(scrollArea), 494, 'there is overflow as 494 > 200px');
+
+    triggerEvent(scrollArea, 'mousemove');
+    assert.ok(find('.no-scrollbar-demo .ember-scrollable .drag-handle.visible'), 'handle shows up visible');
+
+    click(toggleButtonSelector);
+  });
+
+  andThen(function() {
+    assert.equal(elementHeight(scrollArea), 18);
+    assert.ok(find('.no-scrollbar-demo .ember-scrollable .drag-handle:not(.visible)'), 'handle goes away when overflow is gone');
+  });
+
+});

--- a/tests/acceptance/index-test.js
+++ b/tests/acceptance/index-test.js
@@ -1,7 +1,12 @@
 import { test } from 'qunit';
 import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
+import { click, find, fillIn, triggerEvent } from 'ember-native-dom-helpers/test-support/helpers';
 
 moduleForAcceptance('Acceptance | ember-scrollbar');
+
+function elementHeight(elem) {
+  return elem.getBoundingClientRect().height;
+}
 
 test('vertical scrollbar', function(assert) {
   visit('/');
@@ -9,49 +14,57 @@ test('vertical scrollbar', function(assert) {
   andThen(function() {
     assert.equal(currentURL(), '/');
 
-    assert.ok($('.vertical-demo .ember-scrollable').length, 'vertical demo rendered');
-    assert.ok($('.vertical-demo .ember-scrollable .drag-handle').length, 'vertical demo handle rendered');
+    assert.ok(find('.vertical-demo .ember-scrollable'), 'vertical demo rendered');
+    assert.ok(find('.vertical-demo .ember-scrollable .drag-handle'), 'vertical demo handle rendered');
   });
 
 });
 
 test('resizable scrollbar', function(assert) {
+  let elem;
+  const toggleButtonSelector = '.resize-demo button';
   visit('/');
 
   andThen(function() {
-    assert.ok($('.resize-demo .ember-scrollable').length, 'resize demo rendered');
-    assert.ok($('.resize-demo .ember-scrollable .drag-handle').length, 'resize handle rendered');
-    assert.equal($('.resize-demo .ember-scrollable').height(), 200);
+    elem = find('.resize-demo .ember-scrollable');
+
+    assert.ok(find('.resize-demo .ember-scrollable'), 'resize demo rendered');
+    assert.ok(find('.resize-demo .ember-scrollable .drag-handle'), 'resize handle rendered');
+    assert.equal(elementHeight(elem), 200);
+
+    click(toggleButtonSelector); // make tall
+
   });
 
-  click('button:contains(Make Tall)');
+  andThen(function() {
+    assert.equal(elementHeight(elem), 400);
 
-  andThen(function(){
-    assert.equal($('.resize-demo .ember-scrollable').height(), 400);
+    click(toggleButtonSelector); // make small
   });
 
-  click('button:contains(Make Short)');
 
-  andThen(function(){
-    assert.equal($('.resize-demo .ember-scrollable').height(), 200);
+  andThen(function() {
+    assert.equal(elementHeight(elem), 200);
   });
 
 });
 
 test('scrollTo and onScroll', function(assert) {
   visit('/');
+  let offset;
 
   andThen(function() {
-    assert.ok($('.event-and-setter-demo .ember-scrollable').length, 'scrolling demo rendered');
-    assert.ok($('.event-and-setter-demo .ember-scrollable .drag-handle').length, 'scrolling handle rendered');
+    assert.ok(find('.event-and-setter-demo .ember-scrollable'), 'scrolling demo rendered');
+    assert.ok(find('.event-and-setter-demo .ember-scrollable .drag-handle'), 'scrolling handle rendered');
+
+    offset = 123;
+
+    fillIn('#targetScrollOffset input', offset);
   });
 
-  const offset = 123;
-
-  fillIn('#targetScrollOffset input', offset);
-
-  andThen(function(){
-    assert.ok(~$('#currentScrollOffset').text().indexOf(String(offset)), 'scrollOffset matches');
+  andThen(function() {
+    assert.ok(find('#currentScrollOffset').innerText.indexOf(String(offset)) !== -1, 'scrollOffset matches');
   });
 
 });
+

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -95,8 +95,8 @@
 </section>
 
 <section class="no-scrollbar-demo">
-  <h1>No Scroll <button {{action 'toggleHeight'}}>Make {{if isShort 'Overflow' 'No Overflow'}}</button></h1>
-
+  <h1>No Scroll </h1>
+  <button {{action 'toggleHeight'}}>Make {{if isShort 'Overflow' 'No Overflow'}}</button>
   <div class="output">
     {{!-- BEGIN-SNIPPET no-scrollbar-demo --}}
     <div style="height: 200px;">

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -95,13 +95,29 @@
 </section>
 
 <section class="no-scrollbar-demo">
-  <h1>No Scroll</h1>
+  <h1>No Scroll <button {{action 'toggleHeight'}}>Make {{if isShort 'Overflow' 'No Overflow'}}</button></h1>
 
   <div class="output">
     {{!-- BEGIN-SNIPPET no-scrollbar-demo --}}
     <div style="height: 200px;">
       {{#ember-scrollable}}
         <p>Some content</p>
+        {{#unless isShort}}
+          <p>Some content</p>
+          <p>Some content</p>
+          <p>Some content</p>
+          <p>Some content</p>
+          <p>Some content</p>
+          <p>Some content</p>
+          <p>Some content</p>
+          <p>Some content</p>
+          <p>Some content</p>
+          <p>Some content</p>
+          <p>Some content</p>
+          <p>Some content</p>
+          <p>Some content</p>
+          <p>Some content</p>
+        {{/unless}}
       {{/ember-scrollable}}
     </div>
     {{!-- END-SNIPPET --}}


### PR DESCRIPTION
cc @offirgolan @bugduino  closes https://github.com/offirgolan/ember-light-table/issues/323

I merged https://github.com/alphasights/ember-scrollable/pull/57 into this branch because I wanted to use `ember-native-dom-helpers` and didn't want to get conflicts...
I'll leave #57 open to figure out the aynsc scroll stuff.