### PR TITLE
Mouse Events on Window Instead of DOM

### DIFF
--- a/addon/components/ember-scrollable.js
+++ b/addon/components/ember-scrollable.js
@@ -123,8 +123,8 @@ export default Ember.Component.extend(InboundActionsMixin, DomMixin, {
     this._super(...arguments);
     this.setupElements();
     scheduleOnce('afterRender', this, this.createScrollbarAndShowIfNecessary);
-    this.addEventListener(document.body, 'mouseup', (e) => this.endDrag(e));
-    this.addEventListener(document.body, 'mousemove', (e) => {
+    this.addEventListener(window, 'mouseup', (e) => this.endDrag(e));
+    this.addEventListener(window, 'mousemove', (e) => {
       throttle(this, this.updateMouseOffset, e, THROTTLE_TIME_LESS_THAN_60_FPS_IN_MS);
     });
     this.setupResize();

--- a/addon/components/ember-scrollable.js
+++ b/addon/components/ember-scrollable.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import InboundActionsMixin from 'ember-component-inbound-actions/inbound-actions';
 import DomMixin from 'ember-lifeline/mixins/dom';
 import layout from '../templates/components/ember-scrollable';
-import {Horizontal, Vertical} from '../classes/scrollable';
+import { Horizontal, Vertical } from '../classes/scrollable';
 
 const {
   computed,
@@ -350,7 +350,7 @@ export default Ember.Component.extend(InboundActionsMixin, DomMixin, {
    * @private
    */
   updateMouseOffset(e){
-    const {pageX, pageY} = e;
+    const { pageX, pageY } = e;
     this.set('horizontalMouseOffset', pageX);
     this.set('verticalMouseOffset', pageY);
   },
@@ -378,7 +378,7 @@ export default Ember.Component.extend(InboundActionsMixin, DomMixin, {
    * @private
    */
   updateScrollbarAndSetupProperties(scrollOffset, scrollbarDirection) {
-    const {handleOffset, handleSize} = this.get(`${scrollbarDirection}Scrollbar`).getHandlePositionAndSize(scrollOffset);
+    const { handleOffset, handleSize } = this.get(`${scrollbarDirection}Scrollbar`).getHandlePositionAndSize(scrollOffset);
     this.set(`${scrollbarDirection}HandleOffset`, handleOffset);
     this.set(`${scrollbarDirection}HandleSize`, handleSize);
   },

--- a/addon/components/ember-scrollbar.js
+++ b/addon/components/ember-scrollbar.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import layout from '../templates/components/ember-scrollbar';
-import {styleify} from '../util/css';
+import { styleify } from '../util/css';
 
 const {
   computed,
@@ -48,11 +48,11 @@ export default Ember.Component.extend({
 
 
   handleStylesJSON: computed('handleOffset', 'handleSize', 'horizontal', function() {
-    const {handleOffset, handleSize} = this.getProperties('handleOffset', 'handleSize');
+    const { handleOffset, handleSize } = this.getProperties('handleOffset', 'handleSize');
     if (this.get('horizontal')) {
-      return {left: handleOffset + 'px', width: handleSize + 'px'};
+      return { left: handleOffset + 'px', width: handleSize + 'px' };
     } else {
-      return {top: handleOffset + 'px', height: handleSize + 'px'};
+      return { top: handleOffset + 'px', height: handleSize + 'px' };
     }
   }),
 

--- a/addon/components/scroll-content-element.js
+++ b/addon/components/scroll-content-element.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import layout from '../templates/components/scroll-content-element';
 import DomMixin from 'ember-lifeline/mixins/dom';
-import {styleify} from '../util/css';
+import { styleify } from '../util/css';
 
 const {
   computed,
@@ -88,8 +88,8 @@ export default Ember.Component.extend(DomMixin, {
    * @private
    */
   stylesJSON: computed('height', 'width', function() {
-    const {height, width} = this.getProperties('height', 'width');
-    return {width: width + 'px', height: height + 'px'};
+    const { height, width } = this.getProperties('height', 'width');
+    return { width: width + 'px', height: height + 'px' };
   }),
 
   /**

--- a/addon/util/css.js
+++ b/addon/util/css.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 
-const {isEmpty, String: {htmlSafe}} = Ember;
+const { isEmpty, String: { htmlSafe } } = Ember;
 
 function styleify(obj) {
   if (isEmpty(obj)) {
@@ -17,4 +17,4 @@ function styleify(obj) {
 
 }
 
-export {styleify};
+export { styleify };


### PR DESCRIPTION
cc @offirgolan 
Closes https://github.com/alphasights/ember-scrollable/issues/59

>Adding event listeners to window object
Instead of document.body, this allows for the mousemove being tracked even
outside of browser window, similar to how native browsers work.
If you drag and move the mouse outside of the browser window,
the scrollbar should still scroll until you mouseup

@nem-jmalatin let me know if this behaves as you expect.
