### PR TITLE
calculate scrollbar width correctly

### DIFF
--- a/addon/components/ember-scrollable.js
+++ b/addon/components/ember-scrollable.js
@@ -15,8 +15,7 @@ const {
     scheduleOnce,
     debounce,
     throttle
-  },
-  $
+  }
 } = Ember;
 
 const hideDelay = Ember.testing ? 16 : 1000;

--- a/addon/components/ember-scrollable.js
+++ b/addon/components/ember-scrollable.js
@@ -67,10 +67,10 @@ export default Ember.Component.extend(InboundActionsMixin, DomMixin, {
    * @type Number
    */
   scrollTo: computed('vertical', {
-    get(){
+    get() {
       return this.get('vertical') ? this.get('scrollToY') : this.get('scrollToX');
     },
-    set(key, value){
+    set(key, value) {
       // TODO this is deprecated. remove eventually.
       deprecate('Using the `scrollTo` property directly has been deprecated, please prefer being explicit by using `scrollToX` and `scrollToY`.');
       const prop = this.get('vertical') ? 'scrollToY' : 'scrollToX';
@@ -234,40 +234,34 @@ export default Ember.Component.extend(InboundActionsMixin, DomMixin, {
     this._contentElement = this.$(`${contentSelector}:first`);
   },
 
+  /**
+  * Original function by Jonathan Sharp:
+  * http://jdsharp.us/jQuery/minute/calculate-scrollbar-width.php
+  *
+  * Modified to work with newer jQuery version.
+  *
+  * @property scrollbarThickness
+  * @private
+  * @type Number
+  */
+  scrollbarThickness: computed(() => {
+    // Append a temporary scrolling element to the DOM, then measure
+    // the difference between between its outer and inner elements.
+    let tempEl = $(`
+      <div class="scrollbar-width-tester" style="width: 50px; position: absolute; top: 0px;">
+        <div style="overflow: scroll;">
+          <div class="scrollbar-width-tester__inner"></div>
+        </div>
+      </div>
+    `);
+    $('body').append(tempEl);
+    let width = $(tempEl).width();
+    let widthMinusScrollbars = $('.scrollbar-width-tester__inner', tempEl).width();
+    tempEl.remove();
 
-  measureScrollbar() {
+    return (width - widthMinusScrollbars);
+  }),
 
-    /**
-     * Calculate scrollbar width
-     *
-     * Original function by Jonathan Sharp:
-     * http://jdsharp.us/jQuery/minute/calculate-scrollbar-width.php
-     * Updated to work in Chrome v25.
-     */
-    function scrollbarWidth() {
-      // Append a temporary scrolling element to the DOM, then measure
-      // the difference between between its outer and inner elements.
-      var tempEl = $('<div class="scrollbar-width-tester" style="width:50px;height:50px;overflow-y:scroll;position:absolute;top:-200px;left:-200px;"><div style="height:100px;"></div>');
-      $('body').append(tempEl);
-      var width = $(tempEl).innerWidth();
-      var widthMinusScrollbars = $('div', tempEl).innerWidth();
-      tempEl.remove();
-
-      // On OS X if the scrollbar is set to auto hide it will have zero width. On webkit we can still
-      // hide it using ::-webkit-scrollbar { width:0; height:0; } but there is no moz equivalent. So we're
-      // forced to sniff Firefox and return a hard-coded scrollbar width. I know, I know...
-
-      // https://github.com/alphasights/ember-scrollable/issues/34
-      // if (width === widthMinusScrollbars && navigator.userAgent.toLowerCase().indexOf('firefox') > -1) {
-      //  return 17;
-      // }
-
-      return (width - widthMinusScrollbars);
-    }
-
-    return scrollbarWidth();
-
-  },
 
   /**
    * Used to create/reset scrollbar(s) if they are necessary
@@ -286,7 +280,7 @@ export default Ember.Component.extend(InboundActionsMixin, DomMixin, {
     });
   },
 
-  _resizeHandler(){
+  _resizeHandler() {
     debounce(this, this.resizeScrollbar, 16);
   },
 
@@ -297,7 +291,7 @@ export default Ember.Component.extend(InboundActionsMixin, DomMixin, {
   resizeScrollContent() {
     const width = this.$().width();
     const height = this.$().height();
-    const scrollbarThickness = this.measureScrollbar();
+    const scrollbarThickness = this.get('scrollbarThickness');
 
     const hasHorizontal = this.get('horizontal');
     const hasVertical = this.get('vertical');
@@ -305,15 +299,13 @@ export default Ember.Component.extend(InboundActionsMixin, DomMixin, {
     if (hasHorizontal && hasVertical) {
       this.set('scrollContentWidth', width + scrollbarThickness);
       this.set('scrollContentHeight', height + scrollbarThickness);
+    } else if (hasHorizontal) {
+      this.set('scrollContentWidth', width);
+      this.set('scrollContentHeight', height + scrollbarThickness);
+      this._contentElement.height(height);
     } else {
-      if (hasHorizontal) {
-        this.set('scrollContentWidth', width);
-        this.set('scrollContentHeight', height + scrollbarThickness);
-        this._contentElement.height(height);
-      } else {
-        this.set('scrollContentWidth', width + scrollbarThickness);
-        this.set('scrollContentHeight', height);
-      }
+      this.set('scrollContentWidth', width + scrollbarThickness);
+      this.set('scrollContentHeight', height);
     }
   },
 
@@ -358,7 +350,7 @@ export default Ember.Component.extend(InboundActionsMixin, DomMixin, {
    * @method mouseMove
    * @private
    */
-  mouseMove(){
+  mouseMove() {
     if (this.get('autoHide')) {
       throttle(this, this.showScrollbar, THROTTLE_TIME_LESS_THAN_60_FPS_IN_MS);
     }
@@ -371,7 +363,7 @@ export default Ember.Component.extend(InboundActionsMixin, DomMixin, {
    * @param e
    * @private
    */
-  updateMouseOffset(e){
+  updateMouseOffset(e) {
     const { pageX, pageY } = e;
     this.set('horizontalMouseOffset', pageX);
     this.set('verticalMouseOffset', pageY);
@@ -549,7 +541,7 @@ export default Ember.Component.extend(InboundActionsMixin, DomMixin, {
       // TODO some might expect the `scrollToY` action to be called here
       this.set('scrollToY', 0);
     },
-    scrolled(){
+    scrolled() {
       scheduleOnce('afterRender', this, 'scrolled', ...arguments);
     },
     horizontalDrag(dragPerc) {

--- a/addon/components/ember-scrollable.js
+++ b/addon/components/ember-scrollable.js
@@ -8,6 +8,9 @@ const {
   computed,
   deprecate,
   isPresent,
+  inject: {
+    service
+  },
   run: {
     scheduleOnce,
     debounce,
@@ -129,6 +132,8 @@ export default Ember.Component.extend(InboundActionsMixin, DomMixin, {
    */
   verticalScrollbar: null,
 
+  scrollbarThickness: service(),
+
   didReceiveAttrs() {
     const horizontal = this.get('horizontal');
     const vertical = this.get('horizontal');
@@ -235,35 +240,6 @@ export default Ember.Component.extend(InboundActionsMixin, DomMixin, {
   },
 
   /**
-  * Original function by Jonathan Sharp:
-  * http://jdsharp.us/jQuery/minute/calculate-scrollbar-width.php
-  *
-  * Modified to work with newer jQuery version.
-  *
-  * @property scrollbarThickness
-  * @private
-  * @type Number
-  */
-  scrollbarThickness: computed(() => {
-    // Append a temporary scrolling element to the DOM, then measure
-    // the difference between between its outer and inner elements.
-    let tempEl = $(`
-      <div class="scrollbar-width-tester" style="width: 50px; position: absolute; top: 0px;">
-        <div style="overflow: scroll;">
-          <div class="scrollbar-width-tester__inner"></div>
-        </div>
-      </div>
-    `);
-    $('body').append(tempEl);
-    let width = $(tempEl).width();
-    let widthMinusScrollbars = $('.scrollbar-width-tester__inner', tempEl).width();
-    tempEl.remove();
-
-    return (width - widthMinusScrollbars);
-  }),
-
-
-  /**
    * Used to create/reset scrollbar(s) if they are necessary
    *
    * @method createScrollbarAndShowIfNecessary
@@ -291,7 +267,7 @@ export default Ember.Component.extend(InboundActionsMixin, DomMixin, {
   resizeScrollContent() {
     const width = this.$().width();
     const height = this.$().height();
-    const scrollbarThickness = this.get('scrollbarThickness');
+    const scrollbarThickness = this.get('scrollbarThickness.thickness');
 
     const hasHorizontal = this.get('horizontal');
     const hasVertical = this.get('vertical');

--- a/addon/services/scrollbar-thickness.js
+++ b/addon/services/scrollbar-thickness.js
@@ -2,7 +2,8 @@ import Ember from 'ember';
 
 const {
   computed,
-  Service
+  Service,
+  $
 } = Ember;
 
 export default Service.extend({

--- a/addon/services/scrollbar-thickness.js
+++ b/addon/services/scrollbar-thickness.js
@@ -1,0 +1,24 @@
+import Ember from 'ember';
+
+const {
+  computed,
+  Service
+} = Ember;
+
+export default Service.extend({
+  thickness: computed(() => {
+    const tempEl = $(`
+      <div class="scrollbar-width-tester" style="width: 50px; position: absolute; left: -100px;">
+        <div style="overflow: scroll;">
+          <div class="scrollbar-width-tester__inner"></div>
+        </div>
+      </div>
+    `);
+    $('body').append(tempEl);
+    const width = $(tempEl).width();
+    const widthMinusScrollbars = $('.scrollbar-width-tester__inner', tempEl).width();
+    tempEl.remove();
+
+    return (width - widthMinusScrollbars);
+  })
+});

--- a/app/services/scrollbar-thickness.js
+++ b/app/services/scrollbar-thickness.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-scrollable/services/scrollbar-thickness';


### PR DESCRIPTION
Fixes #64

Scrollbar width is still calculated repeatedly; once for every component.