### PR TITLE
Fix a return value when our component has been torn down

### DIFF
--- a/addon/components/ember-scrollable.js
+++ b/addon/components/ember-scrollable.js
@@ -244,9 +244,6 @@ export default Ember.Component.extend(InboundActionsMixin, DomMixin, {
    * @method createScrollbarAndShowIfNecessary
    */
   createScrollbarAndShowIfNecessary() {
-    if (this.get('isDestroyed')) {
-      return;
-    }
     this.createScrollbar().map((scrollbar) => {
       this.checkScrolledToBottom(scrollbar);
       if (scrollbar.isNecessary) {
@@ -292,7 +289,7 @@ export default Ember.Component.extend(InboundActionsMixin, DomMixin, {
    */
   createScrollbar() {
     if (this.get('isDestroyed')) {
-      return;
+      return [];
     }
     const scrollbars = [];
 

--- a/tests/unit/components/ember-scrollable-test.js
+++ b/tests/unit/components/ember-scrollable-test.js
@@ -1,0 +1,24 @@
+import Ember from 'ember';
+import { moduleForComponent, test } from 'ember-qunit';
+
+const {
+  run
+} = Ember;
+
+moduleForComponent('ember-scrollable', 'Unit | Component | ember scrollable', {
+  // Specify the other units that are required for this test
+  needs: ['service:scrollbar-thickness'],
+  unit: true
+});
+
+test('ensure createScrollbar returns an array if destroyed', function(assert) {
+  let component;
+  run(() => {
+    component = this.subject();
+    component.destroy();
+  });
+
+  let scrollbars = component.createScrollbar();
+
+  assert.equal(scrollbars.length, 0);
+});


### PR DESCRIPTION
I ran into this bug while working for a client who is using `ember-light-table`.  We sometimes tear down the table due to user interaction, which can end up hitting this `ember-scrollable` bug.

If the `ember-scrollable` component is torn down mid-way through the `createScrollbarAndShowIfNecessary`, https://github.com/alphasights/ember-scrollable/blob/master/addon/components/ember-scrollable.js#L250 blows up.  It's expecting an array to be returned from `createScrollbar` at all times, but we were returning an `undefined` value instead.

Thanks for all your work on this! ❤️ 
