### PR TITLE
Friendly cleanup

### DIFF
--- a/addon/components/ember-scrollable.js
+++ b/addon/components/ember-scrollable.js
@@ -24,7 +24,6 @@ const PAGE_JUMP_MULTIPLE = 7 / 8;
 const THROTTLE_TIME_LESS_THAN_60_FPS_IN_MS = 1; // 60 fps -> 1 sec / 60 = 16ms
 
 const scrollbarSelector = '.tse-scrollbar';
-const scrollContentSelector = '.tse-scroll-content';
 const contentSelector = '.tse-content';
 
 export default Ember.Component.extend(InboundActionsMixin, DomMixin, {
@@ -225,16 +224,11 @@ export default Ember.Component.extend(InboundActionsMixin, DomMixin, {
    */
   verticalMouseOffset: 0,
 
-  scrollContentSize(sizeAttr) {
-    return this._scrollContentElement[sizeAttr]();
-  },
-
   contentSize(sizeAttr) {
     return this._contentElement[sizeAttr]();
   },
 
   setupElements() {
-    this._scrollContentElement = this.$(`${scrollContentSelector}`);
     this._contentElement = this.$(`${contentSelector}:first`);
   },
 
@@ -473,7 +467,7 @@ export default Ember.Component.extend(InboundActionsMixin, DomMixin, {
    */
   jumpScroll(jumpPositive, scrollToProp, sizeAttr) {
     const scrollOffset = this.get(scrollToProp);
-    let jumpAmt = PAGE_JUMP_MULTIPLE * this.scrollContentSize(sizeAttr);
+    let jumpAmt = PAGE_JUMP_MULTIPLE * this.contentSize(sizeAttr);
     let scrollPos = jumpPositive ? scrollOffset - jumpAmt : scrollOffset + jumpAmt;
     this.set(scrollToProp, scrollPos);
   },

--- a/tests/acceptance/index-test.js
+++ b/tests/acceptance/index-test.js
@@ -77,7 +77,7 @@ test('When element resized from no-overflow => overflow => no-overflow, no scrol
   andThen(function() {
     assert.ok(find('.no-scrollbar-demo .ember-scrollable'), 'resize demo rendered');
     assert.ok(find('.no-scrollbar-demo .ember-scrollable .drag-handle:not(.visible)'), 'resize handle rendered, but not visible');
-    scrollArea = find('.no-scrollbar-demo .ember-scrollable .tse-content');
+    scrollArea = find('.no-scrollbar-demo .ember-scrollable .scrollable-content');
     assert.equal(elementHeight(scrollArea), 18, 'there is no overflow as 18 < 200px');
 
     click(toggleButtonSelector);

--- a/tests/dummy/app/templates/cookbook.hbs
+++ b/tests/dummy/app/templates/cookbook.hbs
@@ -10,7 +10,7 @@
   <div class="output">
     {{!-- BEGIN-SNIPPET vertical --}}
     <div style="height: 400px;">
-      {{#ember-scrollable scrollToY=scrollToY onScroll=(action (mut scrollToY))}}
+      {{#ember-scrollable scrollToY=scrollToY onScrollY=(action (mut scrollToY))}}
         <p>
           {{#draggable-object content=this}}
             Drag Me!
@@ -43,7 +43,7 @@
   <div class="output">
     {{!-- BEGIN-SNIPPET vertical --}}
     <div style="height: 400px;">
-      {{#ember-scrollable scrollToY=scrollToY onScroll=(action (mut scrollToY))}}
+      {{#ember-scrollable scrollToY=scrollToY onScrollY=(action (mut scrollToY))}}
         <p>
           {{#draggable-object content=this}}
             Drag Me!

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -225,7 +225,7 @@
     <div style="height: 400px;">
       {{#ember-scrollable
         scrollToY=targetScrollOffset
-        onScroll=(action (mut currentScrollOffset))
+        onScrollY=(action (mut currentScrollOffset))
       }}
         <p>Some content</p>
         <p>Some more content</p>

--- a/tests/integration/components/scroll-content-element-test.js
+++ b/tests/integration/components/scroll-content-element-test.js
@@ -23,7 +23,7 @@ const VERTICAL_TEMPLATE = hbs`
         height=10
         width=10
         scrollToY=scrollToY
-        onScrollY=(action 'scrolled')
+        onScroll=(action 'scrolled')
       }}
         <div style="height: 40px; width: 40px;">
           Content
@@ -38,7 +38,7 @@ const HORIZONTAL_TEMPLATE = hbs`
         height=10
         width=10
         scrollToX=scrollToX
-        onScrollX=(action 'scrolled')
+        onScroll=(action 'scrolled')
       }}
         <div style="height: 40px; width: 40px;">
           Content

--- a/tests/integration/components/scroll-content-element-test.js
+++ b/tests/integration/components/scroll-content-element-test.js
@@ -23,7 +23,7 @@ const VERTICAL_TEMPLATE = hbs`
         height=10
         width=10
         scrollToY=scrollToY
-        onScroll=(action 'scrolled')
+        onScrollY=(action 'scrolled')
       }}
         <div style="height: 40px; width: 40px;">
           Content
@@ -38,7 +38,7 @@ const HORIZONTAL_TEMPLATE = hbs`
         height=10
         width=10
         scrollToX=scrollToX
-        onScroll=(action 'scrolled')
+        onScrollX=(action 'scrolled')
       }}
         <div style="height: 40px; width: 40px;">
           Content


### PR DESCRIPTION
- changed the usage of `scrollContentSize` to match that of the drag, which was `contentSize`
- fixed deprecation warnings in our own repo, because it's sad when you trigger your own deprecations