### PR TITLE
Fixng scrollbar jumping around bug

### DIFF
--- a/addon/components/ember-scrollable.js
+++ b/addon/components/ember-scrollable.js
@@ -380,6 +380,8 @@ export default Ember.Component.extend(InboundActionsMixin, DomMixin, {
     this.checkScrolledToBottom(this.get(`${scrollDirection}Scrollbar`), scrollOffset);
     const direction = scrollDirection === 'vertical' ? 'Y' : 'X';
     this.get(`onScroll${direction}`)(scrollOffset);
+    // synchronize scrollToX / scrollToY
+    this.set(`scrollTo${direction}`, scrollOffset);
     // TODO this is deprecated. remove eventually.
     this.sendScroll(event, scrollOffset);
   },


### PR DESCRIPTION
When using mousewheel to trigger scroll we need to
make sure we're updating the scrollToX and scrollToY
properties. This was causing a "jumping" around issue
when then using the horizontal scrollbar to scroll
horizontallly after scrolling vertically.
Fixes #72