### PR TITLE
Remove ember-component-inbound-actions

### DIFF
--- a/addon/components/ember-scrollable.js
+++ b/addon/components/ember-scrollable.js
@@ -1,5 +1,4 @@
 import Ember from 'ember';
-import InboundActionsMixin from 'ember-component-inbound-actions/inbound-actions';
 import DomMixin from 'ember-lifeline/mixins/dom';
 import layout from '../templates/components/ember-scrollable';
 import { Horizontal, Vertical } from '../classes/scrollable';
@@ -26,7 +25,7 @@ export const THROTTLE_TIME_LESS_THAN_60_FPS_IN_MS = 1; // 60 fps -> 1 sec / 60 =
 const scrollbarSelector = '.tse-scrollbar';
 const contentSelector = '.tse-content';
 
-export default Ember.Component.extend(InboundActionsMixin, DomMixin, {
+export default Ember.Component.extend(DomMixin, {
   layout,
   classNameBindings: [':ember-scrollable', ':tse-scrollable', 'horizontal', 'vertical'],
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "ember-cli-babel": "^6.8.0",
     "ember-cli-htmlbars": "^2.0.1",
-    "ember-component-inbound-actions": "1.2.1",
     "ember-element-resize-detector": "0.1.5",
     "ember-lifeline": "^2.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2623,12 +2623,6 @@ ember-code-snippet@2.0.0:
     es6-promise "^1.0.0"
     glob "^4.0.4"
 
-ember-component-inbound-actions@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/ember-component-inbound-actions/-/ember-component-inbound-actions-1.2.1.tgz#0f57c7a0cd969d56fbb6affc430189aacfff0779"
-  dependencies:
-    ember-cli-babel "^5.1.7"
-
 ember-disable-prototype-extensions@^1.1.2:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/ember-disable-prototype-extensions/-/ember-disable-prototype-extensions-1.1.3.tgz#1969135217654b5e278f9fe2d9d4e49b5720329e"


### PR DESCRIPTION
ember-component-inbound-actions was introduced in https://github.com/alphasights/ember-scrollable/commit/5d407902dee8d62c32967397d8b1d64100dfc642 though i don't see a reason that occured.

Was it to facilitate other apps/addon controlling ember-scrollable? If that was they case, then i'd argue it's their responsibility to do so (for instance by reopening or extending the ember-scrollable component)