### PR TITLE
Fix lingering performance issues

### DIFF
--- a/addon/components/ember-scrollbar.js
+++ b/addon/components/ember-scrollbar.js
@@ -29,7 +29,6 @@ export default Component.extend(DomMixin, {
   showHandle: false,
   handleSize: null,
   handleOffset: 0,
-  mouseOffset: 0,
 
   offsetAttr: computed('horizontal', function() {
     return this.get('horizontal') ? 'left' : 'top';
@@ -82,15 +81,6 @@ export default Component.extend(DomMixin, {
     this.endDrag();
   },
 
-  didReceiveAttrs() {
-    const mouseOffset = this.get('mouseOffset');
-    if (this.get('isDragging')) {
-      if (isPresent(mouseOffset)) {
-        this._drag(mouseOffset, this.get('dragOffset'));
-      }
-    }
-  },
-
   didInsertElement() {
     this._super(...arguments);
     this.addEventListener(window, 'mousemove', (e) => {
@@ -111,7 +101,11 @@ export default Component.extend(DomMixin, {
    */
   updateMouseOffset(e) {
     const { pageX, pageY } = e;
-    this.set('mouseOffset', this.get('horizontal') ? pageX : pageY);
+    const mouseOffset = this.get('horizontal') ? pageX : pageY;
+
+    if (this.get('isDragging') && isPresent(mouseOffset)) {
+      this._drag(mouseOffset, this.get('dragOffset'));
+    }
   },
 
   /**

--- a/addon/templates/components/ember-scrollable.hbs
+++ b/addon/templates/components/ember-scrollable.hbs
@@ -6,7 +6,6 @@
     horizontal=true
     showHandle=showHandle
     isDragging=isHorizontalDragging
-    mouseOffset=horizontalMouseOffset
     onJumpTo=(action 'horizontalJumpTo')
     onDrag=(action 'horizontalDrag')
     onDragStart=(action 'horizontalDragBoundary' true)
@@ -20,7 +19,6 @@
     horizontal=false
     showHandle=showHandle
     isDragging=isVerticalDragging
-    mouseOffset=verticalMouseOffset
     onJumpTo=(action 'verticalJumpTo')
     onDrag=(action 'verticalDrag')
     onDragStart=(action 'verticalBoundaryEvent' true)

--- a/tests/integration/components/ember-scrollbar-test.js
+++ b/tests/integration/components/ember-scrollbar-test.js
@@ -311,7 +311,7 @@ module('Integration | Component | ember scrollbar', function(hooks) {
   });
 
 
-  test('Vertical: onDrag is called when a change occurs when onDragging is true and mouseOffset exists', async function(assert) {
+  test('Vertical: onDrag is called when a change occurs when onDragging is true and mousemove event is triggered', async function(assert) {
     assert.expect(1);
 
     this.setProperties({
@@ -334,7 +334,6 @@ module('Integration | Component | ember scrollbar', function(hooks) {
         handleSize=size
         horizontal=false
         dragOffset=30
-        mouseOffset=300
         isDragging=isDragging
         showHandle=true
         onDrag=(action 'onDrag')
@@ -345,10 +344,10 @@ module('Integration | Component | ember scrollbar', function(hooks) {
 
     // WHEN
     this.set('isDragging', true);
-
+    triggerEvent(window, 'mousemove', { pageX: 0, pageY: 0 });
   });
 
-  test('Horizontal: onDrag is called when a change occurs when onDragging is true and mouseOffset exists', async function(assert) {
+  test('Horizontal: onDrag is called when a change occurs when onDragging is true and mousemove event is triggered', async function(assert) {
     assert.expect(1);
 
     this.setProperties({
@@ -370,7 +369,6 @@ module('Integration | Component | ember scrollbar', function(hooks) {
         handleSize=size
         horizontal=true
         dragOffset=30
-        mouseOffset=300
         isDragging=isDragging
         showHandle=true
         onDrag=(action 'onDrag')
@@ -381,7 +379,7 @@ module('Integration | Component | ember scrollbar', function(hooks) {
 
     // WHEN
     this.set('isDragging', true);
-
+    triggerEvent(window, 'mousemove', { pageX: 0, pageY: 0 });
   });
 
   // TODO verify that the drag percentage is calculated from mouse offset and drag offset and is a percentage between 0 and 1 of the scrollbar size


### PR DESCRIPTION
Hey, this is a sort of continuation of #83. I've tried to demo what's happening [here](https://github.com/piotrpalek/scrollable-example).

The issue is that ember-scrollable updates the `mouseOffset` argument at nearly 60fps. In certain conditions (I've noticed it mainly in the usage of `ember-light-table` but there could be others) it means that it triggers re-renders constantly when moving the mouse anywhere over the window. This causes severe performance issues if you for eg. use a `didRender` hook which does some work, since it's constantly triggered.

This PR fixes the issue by removing the passing of `mouseOffset` to the `ember-scrollable` component and instead directly triggers the function which does the main work.