### PR TITLE
Upgrade morgan to avoid arbitrary commands issue

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2382,6 +2382,10 @@ depd@1.1.1, depd@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.1.tgz#5783b4e1c459f06fa5ca27f991f3d06e7a310359"
 
+depd@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
+
 destroy@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
@@ -2810,7 +2814,7 @@ ember-cli@~3.3.0:
     markdown-it "^8.3.0"
     markdown-it-terminal "0.1.0"
     minimatch "^3.0.0"
-    morgan "^1.8.1"
+    morgan "^1.9.1"
     node-modules-path "^1.0.0"
     nopt "^3.0.6"
     npm-package-arg "^6.0.0"
@@ -2861,9 +2865,9 @@ ember-drag-drop@0.4.6:
   dependencies:
     ember-cli-babel "^5.2.4"
 
-ember-element-resize-detector@~0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/ember-element-resize-detector/-/ember-element-resize-detector-0.2.0.tgz#79170a97e59e29ecc07ffe1c5d3b84eb0af06326"
+ember-element-resize-detector@~0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/ember-element-resize-detector/-/ember-element-resize-detector-0.4.0.tgz#e21affa62fc9df5c13f587a940611c05f725c1ef"
   dependencies:
     broccoli-funnel "^1.0.2"
     broccoli-merge-trees "^1.1.1"
@@ -5650,13 +5654,13 @@ moment-timezone@^0.3.0:
   version "2.19.2"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.19.2.tgz#8a7f774c95a64550b4c7ebd496683908f9419dbe"
 
-morgan@^1.8.1:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/morgan/-/morgan-1.9.0.tgz#d01fa6c65859b76fcf31b3cb53a3821a311d8051"
+morgan@^1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/morgan/-/morgan-1.9.1.tgz#0a8d16734a1d9afbc824b99df87e738e58e2da59"
   dependencies:
     basic-auth "~2.0.0"
     debug "2.6.9"
-    depd "~1.1.1"
+    depd "~1.1.2"
     on-finished "~2.3.0"
     on-headers "~1.0.1"
 


### PR DESCRIPTION
Updates `morgan` to avoid the possibility of [arbitrary code execution](https://nvd.nist.gov/vuln/detail/CVE-2019-5413).