### PR TITLE
Temp deprecation fix add ember jquery to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test:all": "ember try:each"
   },
   "dependencies": {
+    "@ember/jquery": "^1.1.0",
     "ember-cli-babel": "^6.8.0",
     "ember-cli-htmlbars": "^2.0.1",
     "ember-component-inbound-actions": "^1.3.0",
@@ -27,6 +28,7 @@
     "ember-lifeline": "^3.0.1"
   },
   "devDependencies": {
+    "@ember/optional-features": "^1.0.0",
     "broccoli-asset-rev": "^2.7.0",
     "ember-ajax": "^3.0.0",
     "ember-cli": "~3.3.0",

--- a/tests/dummy/config/optional-features.json
+++ b/tests/dummy/config/optional-features.json
@@ -1,0 +1,3 @@
+{
+  "jquery-integration": true
+}


### PR DESCRIPTION
As per #105 this will remove the deprecation warning pending removal of jQuery